### PR TITLE
Fix verify restore ordering

### DIFF
--- a/docs/developer-cli.md
+++ b/docs/developer-cli.md
@@ -98,6 +98,7 @@ python ./scripts/dev.py verify --start-backend
 ```
 
 This workflow validates backend XML docs, runs backend tests, lints the OpenAPI spec, and optionally executes the Postman contract suite.
+It restores the backend solution up front, so it works from a fresh clone without a separate manual `dotnet restore`.
 
 ### Authenticate Postman CLI for workspace or mock operations
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -676,12 +676,13 @@ def run_backend_api(config: DevConfig, *, do_restore: bool) -> None:
     run_command(["dotnet", "run", "--project", str(project_path)], cwd=backend_root, check=True)
 
 
-def run_tests(config: DevConfig, *, run_integration: bool) -> None:
+def run_tests(config: DevConfig, *, run_integration: bool, restore: bool = True) -> None:
     """Run backend unit tests and optionally integration tests.
 
     Args:
         config: CLI configuration containing backend test project paths.
         run_integration: Whether to run integration tests after unit tests.
+        restore: Whether each ``dotnet test`` invocation should restore packages first.
 
     Returns:
         None.
@@ -697,17 +698,18 @@ def run_tests(config: DevConfig, *, run_integration: bool) -> None:
         config.repo_root
         / "backend/tests/Board.ThirdPartyLibrary.Api.IntegrationTests/Board.ThirdPartyLibrary.Api.IntegrationTests.csproj"
     )
+    restore_args = [] if restore else ["--no-restore"]
 
     write_step("Running backend unit tests")
     run_command(
-        ["dotnet", "test", str(unit_project), "--filter", "Category!=Integration"],
+        ["dotnet", "test", str(unit_project), *restore_args, "--filter", "Category!=Integration"],
         cwd=backend_root,
     )
 
     if run_integration:
         write_step("Running backend integration tests (Docker/Testcontainers required)")
         run_command(
-            ["dotnet", "test", str(integration_project), "--filter", "Category=Integration"],
+            ["dotnet", "test", str(integration_project), *restore_args, "--filter", "Category=Integration"],
             cwd=backend_root,
         )
     else:
@@ -1171,8 +1173,9 @@ def run_verify(
         None.
     """
 
+    restore_backend(config)
     validate_backend_xml_docs(config)
-    run_tests(config, run_integration=run_integration)
+    run_tests(config, run_integration=run_integration, restore=False)
     run_api_spec_lint(config)
 
     if not run_contract_tests:


### PR DESCRIPTION
## Summary
- restore the backend solution before XML documentation validation in the root verify workflow
- run backend tests on the already-restored assets to avoid redundant restore work
- document that verify works from a fresh clone without a separate manual restore