### PR TITLE
Infer hosted Supabase URL from project ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,6 @@ The supported root-managed environment files live under [`config/`](config):
 - `config/.env.staging`: staging deployment/operator values used by `deploy-staging`
 - `config/.env`: reserved for future production deployment/operator values
 
+For hosted Supabase environments, `SUPABASE_URL` may be omitted when `SUPABASE_PROJECT_REF` is set and the project uses the default hosted Supabase URL. Keep `SUPABASE_URL` explicit for local development, custom domains, and any non-default routing.
+
 Do not commit those live `.env` files. Only the checked-in `*.example` templates should be tracked.

--- a/config/.env.example
+++ b/config/.env.example
@@ -2,6 +2,8 @@ BOARD_ENTHUSIASTS_APP_ENV=production
 BOARD_ENTHUSIASTS_SPA_BASE_URL=https://boardenthusiasts.com
 BOARD_ENTHUSIASTS_WORKERS_BASE_URL=https://api.boardenthusiasts.com
 SUPABASE_PROJECT_REF=replace-me
+# Optional when using the default hosted Supabase URL for the project ref above.
+# Keep SUPABASE_URL explicit for custom domains or any non-default routing.
 SUPABASE_URL=https://replace-me.supabase.co
 SUPABASE_PUBLISHABLE_KEY=replace-me
 SUPABASE_SECRET_KEY=replace-me

--- a/config/.env.local.example
+++ b/config/.env.local.example
@@ -1,6 +1,7 @@
 BOARD_ENTHUSIASTS_APP_ENV=local
 BOARD_ENTHUSIASTS_SPA_BASE_URL=http://127.0.0.1:4173
 BOARD_ENTHUSIASTS_WORKERS_BASE_URL=http://127.0.0.1:8787
+# Keep the local Supabase URL explicit. Hosted project-ref inference is not used for local development.
 SUPABASE_URL=http://127.0.0.1:55421
 SUPABASE_PUBLISHABLE_KEY=replace-with-local-cli-output
 SUPABASE_SECRET_KEY=replace-with-local-cli-output

--- a/config/.env.staging.example
+++ b/config/.env.staging.example
@@ -2,6 +2,8 @@ BOARD_ENTHUSIASTS_APP_ENV=staging
 BOARD_ENTHUSIASTS_SPA_BASE_URL=https://staging.boardenthusiasts.com
 BOARD_ENTHUSIASTS_WORKERS_BASE_URL=https://api.staging.boardenthusiasts.com
 SUPABASE_PROJECT_REF=replace-me
+# Optional when using the default hosted Supabase URL for the project ref above.
+# Keep SUPABASE_URL explicit for custom domains or any non-default routing.
 SUPABASE_URL=https://replace-me.supabase.co
 SUPABASE_PUBLISHABLE_KEY=replace-me
 SUPABASE_SECRET_KEY=replace-me

--- a/docs/developer-cli.md
+++ b/docs/developer-cli.md
@@ -270,12 +270,22 @@ python ./scripts/dev.py deploy-staging --workers-only
 
 - `BOARD_ENTHUSIASTS_WORKERS_BASE_URL`
 - `SUPABASE_URL`
+- `SUPABASE_PROJECT_REF`
 - `SUPABASE_PUBLISHABLE_KEY`
 - `SUPABASE_SECRET_KEY`
 - `VITE_TURNSTILE_SITE_KEY`
 - `TURNSTILE_SECRET_KEY`
 - `BREVO_API_KEY`
 - `BREVO_SIGNUPS_LIST_ID`
+
+`SUPABASE_URL` remains supported everywhere. When `SUPABASE_URL` is blank and `SUPABASE_PROJECT_REF` is set, the root CLI infers the default hosted URL as `https://<project-ref>.supabase.co`.
+
+Precedence rules:
+
+- explicit `SUPABASE_URL` wins
+- otherwise the CLI infers the default hosted URL from `SUPABASE_PROJECT_REF`
+- local development should keep an explicit local `SUPABASE_URL`
+- custom domains and vanity subdomains should keep an explicit `SUPABASE_URL`
 
 When `deploy-staging` runs a real Workers deployment, it also syncs the Cloudflare Worker secrets from that same root staging file before deploying the Worker bundle.
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -360,12 +360,43 @@ def apply_environment_file(path: Path, *, preserve_existing: bool = True) -> dic
     return parsed
 
 
+def infer_supabase_url_from_environment() -> str | None:
+    """Infer the default hosted Supabase URL when only the project ref is available.
+
+    Returns:
+        The inferred hosted Supabase URL when safe, otherwise ``None``.
+    """
+
+    explicit_url = os.environ.get("SUPABASE_URL", "").strip()
+    if explicit_url:
+        return explicit_url
+
+    app_env = os.environ.get("BOARD_ENTHUSIASTS_APP_ENV", "").strip().lower()
+    if app_env == "local":
+        return None
+
+    project_ref = os.environ.get("SUPABASE_PROJECT_REF", "").strip()
+    if not project_ref:
+        return None
+
+    return f"https://{project_ref}.supabase.co"
+
+
+def normalize_supabase_environment() -> None:
+    """Normalize derived Supabase environment values for the current CLI process."""
+
+    inferred_url = infer_supabase_url_from_environment()
+    if inferred_url:
+        os.environ["SUPABASE_URL"] = inferred_url
+
+
 def auto_load_command_environment(config: DevConfig, *, command_name: str) -> Path | None:
     """Load the root-managed environment file relevant to the current CLI command."""
 
     if command_name == "deploy-staging":
         env_path = get_environment_file_path(config, target="staging")
         apply_environment_file(env_path)
+        normalize_supabase_environment()
         return env_path if env_path.exists() else None
 
     if command_name == "env":
@@ -373,6 +404,7 @@ def auto_load_command_environment(config: DevConfig, *, command_name: str) -> Pa
 
     env_path = get_environment_file_path(config, target="local")
     apply_environment_file(env_path)
+    normalize_supabase_environment()
     return env_path if env_path.exists() else None
 
 

--- a/tests/root_cli/test_dev_cli.py
+++ b/tests/root_cli/test_dev_cli.py
@@ -101,6 +101,64 @@ class DevCliMigrationHelperTests(unittest.TestCase):
 
             self.assertEqual({"FIRST": "from-file", "SECOND": "from-file"}, parsed)
 
+    def test_infer_supabase_url_from_project_ref_for_hosted_env(self) -> None:
+        with mock.patch.dict(
+            dev.os.environ,
+            {
+                "BOARD_ENTHUSIASTS_APP_ENV": "staging",
+                "SUPABASE_PROJECT_REF": "project-ref-123",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                "https://project-ref-123.supabase.co",
+                dev.infer_supabase_url_from_environment(),
+            )
+
+    def test_infer_supabase_url_respects_explicit_override_for_custom_domains(self) -> None:
+        with mock.patch.dict(
+            dev.os.environ,
+            {
+                "BOARD_ENTHUSIASTS_APP_ENV": "production",
+                "SUPABASE_PROJECT_REF": "project-ref-123",
+                "SUPABASE_URL": "https://supabase.boardenthusiasts.com",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                "https://supabase.boardenthusiasts.com",
+                dev.infer_supabase_url_from_environment(),
+            )
+
+    def test_infer_supabase_url_does_not_override_local_environment(self) -> None:
+        with mock.patch.dict(
+            dev.os.environ,
+            {
+                "BOARD_ENTHUSIASTS_APP_ENV": "local",
+                "SUPABASE_PROJECT_REF": "local-dev",
+            },
+            clear=True,
+        ):
+            self.assertIsNone(dev.infer_supabase_url_from_environment())
+
+    def test_auto_load_command_environment_normalizes_inferred_supabase_url(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = pathlib.Path(temp_dir)
+            args = self.create_args()
+            config = dev.config_from_args(args, repo_root)
+            staging_env_path = repo_root / config.staging_env_file
+            staging_env_path.parent.mkdir(parents=True, exist_ok=True)
+            staging_env_path.write_text(
+                "BOARD_ENTHUSIASTS_APP_ENV=staging\nSUPABASE_PROJECT_REF=project-ref-123\n",
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(dev.os.environ, {}, clear=True):
+                loaded_path = dev.auto_load_command_environment(config, command_name="deploy-staging")
+                self.assertEqual("https://project-ref-123.supabase.co", dev.os.environ["SUPABASE_URL"])
+
+            self.assertEqual(staging_env_path, loaded_path)
+
     def test_build_migration_frontend_environment_can_force_landing_mode(self) -> None:
         args = self.create_args()
         config = dev.config_from_args(args, pathlib.Path.cwd())


### PR DESCRIPTION
## Summary\n- infer SUPABASE_URL from SUPABASE_PROJECT_REF for hosted Supabase environments when the URL is omitted\n- preserve explicit SUPABASE_URL precedence for local development and custom domains\n- document the precedence rules and cover the inference path with root CLI tests\n\n## Testing\n- python -m unittest tests.root_cli.test_dev_cli\n- python scripts/dev.py env staging --help\n\nFixes #49