### PR TITLE
Fix Pages smoke check for SEO title changes

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -4704,9 +4704,9 @@ def is_expected_pages_shell_html(html: str) -> bool:
 
     normalized = html.lower()
     return (
-        "<title>board enthusiasts</title>" in normalized
-        and '<div id="root"></div>' in normalized
+        '<div id="root"></div>' in normalized
         and "/assets/index-" in normalized
+        and "board enthusiasts" in normalized
         and "nothing is here yet" not in normalized
         and "error 1014" not in normalized
     )

--- a/tests/root_cli/test_dev_cli.py
+++ b/tests/root_cli/test_dev_cli.py
@@ -893,7 +893,7 @@ class DevCliMigrationHelperTests(unittest.TestCase):
 <!doctype html>
 <html lang="en">
   <head>
-    <title>Board Enthusiasts</title>
+    <title>Board Enthusiasts | Community Hub for Board Players and Builders</title>
     <script type="module" crossorigin src="/assets/index-abc123.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-def456.css">
   </head>
@@ -904,6 +904,23 @@ class DevCliMigrationHelperTests(unittest.TestCase):
 """
 
         self.assertTrue(dev.is_expected_pages_shell_html(html))
+
+    def test_is_expected_pages_shell_html_rejects_unrelated_shell_without_brand_marker(self) -> None:
+        html = """
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Example App</title>
+    <script type="module" crossorigin src="/assets/index-abc123.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-def456.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+"""
+
+        self.assertFalse(dev.is_expected_pages_shell_html(html))
 
     def test_is_expected_pages_shell_html_rejects_cloudflare_placeholder(self) -> None:
         html = """


### PR DESCRIPTION
## Summary\n- relax the Pages smoke title check so it accepts the updated SEO-enhanced landing title\n- keep the guard against Cloudflare placeholder pages and unrelated shells\n- add regression coverage for the new behavior\n\n## Testing\n- python -m unittest tests.root_cli.test_dev_cli