### PR TITLE
Exclude be-home from manual deploy checkout

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -87,7 +87,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize required public submodules
+        run: git submodule update --init --depth=1 api backend frontend
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- stop manual deploy from recursively fetching every submodule
- initialize only the required public submodules for root deploy flows
- keep private be-home out of root deploy checkout

## Validation
- python -m py_compile scripts/dev.py
- python -m unittest discover -s tests/root_cli -p "test_*.py"